### PR TITLE
feat: Add Linux build support to Tauri configuration

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "appimage", "msi", "app", "dmg", "updater"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -67,6 +67,18 @@
         "type": "embedBootstrapper"
       },
       "wix": null
+    },
+    "deb": {
+      "depends": [
+        "libwebkit2gtk-4.0-37",
+        "libgtk-3-0",
+        "librsvg2-common",
+        "libappindicator3-1"
+      ],
+      "files": {}
+    },
+    "appimage": {
+      "bundleMediaFramework": false
     }
   }
 }


### PR DESCRIPTION
This commit updates the `tauri.conf.json` to enable building the application for Linux distributions.

Key changes:
- Modified `bundle.targets` to explicitly include "deb" and "appimage" bundle types.
- Added a `deb` configuration object with common dependencies for Debian-based systems (e.g., Ubuntu), including:
    - libwebkit2gtk-4.0-37
    - libgtk-3-0
    - librsvg2-common
    - libappindicator3-1
- Added an `appimage` configuration object with `bundleMediaFramework` set to false by default.

These changes will allow the project to generate .deb packages and .AppImage files, broadening the application's availability on Linux platforms.